### PR TITLE
remove click handler from StateProx components

### DIFF
--- a/src/components/StateProxDesire.vue
+++ b/src/components/StateProxDesire.vue
@@ -1,6 +1,6 @@
 <template>
     <g>
-        <circle :r="r" :cx="cx" :cy="cy" @click="handleClick" class="state-prox-d"></circle>
+        <circle :r="r" :cx="cx" :cy="cy" class="state-prox-d"></circle>
     </g>
 </template>
 
@@ -17,12 +17,6 @@
             cx: { type: Number, default: 30/Math.SQRT2/2 },
             cy: { type: Number, default: 30/Math.SQRT2/2 },
             r: { type: Number, default: 8 },
-            click: { type: Function, default: () => {} }
         },
-        methods: {
-            handleClick() {
-                this.$emit('click');
-            }
-        }
     }
 </script>

--- a/src/components/StateProxEssential.vue
+++ b/src/components/StateProxEssential.vue
@@ -1,6 +1,6 @@
 <template>
     <g>
-        <circle :r="r" :cx="cx" :cy="cy" @click="handleClick" class="state-prox-e"></circle>
+        <circle :r="r" :cx="cx" :cy="cy" class="state-prox-e"></circle>
     </g>
 </template>
 
@@ -19,13 +19,6 @@
             cx: { type: Number, default: 30/Math.SQRT2/2 },
             cy: { type: Number, default: 30/Math.SQRT2/2 },
             r: { type: Number, default: 8 },
-            click: { type: Function, default: () => {} }
         },
-        methods: {
-            handleClick() {
-                this.$emit('click');
-                //this.console.log('Emitted Sep E');
-            }
-        }
     }
 </script>

--- a/src/components/StateSepDesire.vue
+++ b/src/components/StateSepDesire.vue
@@ -1,6 +1,6 @@
 <template>
     <g>
-        <circle :r="r" :cx="cx" :cy="cy" @click="handleClick" class="state-sep-d"></circle>
+        <circle :r="r" :cx="cx" :cy="cy" class="state-sep-d"></circle>
     </g>
 </template>
 
@@ -19,12 +19,6 @@
             cx: { type: Number, default: 30/Math.SQRT2/2 },
             cy: { type: Number, default: 30/Math.SQRT2/2 },
             r: { type: Number, default: 8 },
-            click: { type: Function, default: () => {} }
         },
-        methods: {
-            handleClick() {
-                this.$emit('click');
-            }
-        }
     }
 </script>

--- a/src/components/StateSepEssential.vue
+++ b/src/components/StateSepEssential.vue
@@ -1,6 +1,6 @@
 <template>
     <g>
-        <circle :r="r" :cx="cx" :cy="cy" @click="handleClick" class="state-sep-e"></circle>
+        <circle :r="r" :cx="cx" :cy="cy" class="state-sep-e"></circle>
     </g>
 </template>
 
@@ -19,13 +19,6 @@
             cx: { type: Number, default: 30/Math.SQRT2/2 },
             cy: { type: Number, default: 30/Math.SQRT2/2 },
             r: { type: Number, default: 8 },
-            click: { type: Function, default: () => {} }
         },
-        methods: {
-            handleClick() {
-                this.$emit('click');
-                //console.log('Emitted Sep E');
-            }
-        }
     }
 </script>


### PR DESCRIPTION
The click handler was firing twice, removing the inner emit fixes this. To avoid confusion I also got rid of the internal click handler